### PR TITLE
Fix addon packaging

### DIFF
--- a/client/version_control/version.py
+++ b/client/version_control/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-"""Package declaring addon version."""
-__version__ = "0.0.1"
+"""Package declaring version_control addon version."""
+__version__ = "0.0.2"

--- a/create_package.py
+++ b/create_package.py
@@ -28,6 +28,7 @@ import argparse
 import logging
 import collections
 import zipfile
+from typing import Optional, Any, Pattern
 
 import package
 
@@ -40,8 +41,14 @@ CLIENT_VERSION_CONTENT = '''# -*- coding: utf-8 -*-
 __version__ = "{}"
 '''
 
+CURRENT_DIR: str = os.path.dirname(os.path.abspath(__file__))
+SERVER_DIR: str = os.path.join(CURRENT_DIR, "server")
+CLIENT_DIR: str = os.path.join(CURRENT_DIR, "client")
+
+COMMON_DIR: str = os.path.join(CLIENT_DIR, ADDON_CLIENT_DIR, "common")
+
 # Patterns of directories to be skipped for server part of addon
-IGNORE_DIR_PATTERNS = [
+IGNORE_DIR_PATTERNS: list[Pattern] = [
     re.compile(pattern)
     for pattern in {
         # Skip directories starting with '.'
@@ -52,7 +59,7 @@ IGNORE_DIR_PATTERNS = [
 ]
 
 # Patterns of files to be skipped for server part of addon
-IGNORE_FILE_PATTERNS = [
+IGNORE_FILE_PATTERNS: list[Pattern] = [
     re.compile(pattern)
     for pattern in {
         # Skip files starting with '.'
@@ -87,7 +94,7 @@ class ZipFileLongPaths(zipfile.ZipFile):
         )
 
 
-def safe_copy_file(src_path, dst_path):
+def safe_copy_file(src_path: str, dst_path: str):
     """Copy file and make sure destination directory exists.
 
     Ignore if destination already contains directories from source.
@@ -100,7 +107,7 @@ def safe_copy_file(src_path, dst_path):
     if src_path == dst_path:
         return
 
-    dst_dir = os.path.dirname(dst_path)
+    dst_dir: str = os.path.dirname(dst_path)
     try:
         os.makedirs(dst_dir)
     except Exception:
@@ -109,7 +116,7 @@ def safe_copy_file(src_path, dst_path):
     shutil.copy2(src_path, dst_path)
 
 
-def _value_match_regexes(value, regexes):
+def _value_match_regexes(value: str, regexes: list[Pattern]) -> bool:
     for regex in regexes:
         if regex.search(value):
             return True
@@ -117,18 +124,22 @@ def _value_match_regexes(value, regexes):
 
 
 def find_files_in_subdir(
-    src_path,
-    ignore_file_patterns=None,
-    ignore_dir_patterns=None
-):
+    src_path: str,
+    ignore_file_patterns: Optional[list[Pattern]] = None,
+    ignore_dir_patterns: Optional[list[Pattern]] = None
+) -> list[tuple[str, str]]:
+    if not os.path.exists(src_path):
+        return []
     if ignore_file_patterns is None:
-        ignore_file_patterns = IGNORE_FILE_PATTERNS
+        ignore_file_patterns: list[Pattern] = IGNORE_FILE_PATTERNS
 
     if ignore_dir_patterns is None:
-        ignore_dir_patterns = IGNORE_DIR_PATTERNS
-    output = []
+        ignore_dir_patterns: list[Pattern] = IGNORE_DIR_PATTERNS
+    output: list[tuple[str, str]] = []
 
-    hierarchy_queue = collections.deque()
+    hierarchy_queue: collections.deque[tuple[str, list[str]]] = (
+        collections.deque()
+    )
     hierarchy_queue.append((src_path, []))
     while hierarchy_queue:
         item = hierarchy_queue.popleft()
@@ -150,7 +161,11 @@ def find_files_in_subdir(
     return output
 
 
-def copy_server_content(addon_output_dir, current_dir, log):
+def copy_server_content(
+    addon_output_dir: str,
+    current_dir: str,
+    log: logging.Logger
+):
     """Copies server side folders to 'addon_package_dir'
 
     Args:
@@ -161,60 +176,87 @@ def copy_server_content(addon_output_dir, current_dir, log):
 
     log.info("Copying server content")
 
-    filepaths_to_copy = []
-    server_dirpath = os.path.join(current_dir, "server")
+    filepaths_to_copy: list[tuple[str, str]] = []
 
-    for item in find_files_in_subdir(server_dirpath):
-        src_path, dst_subpath = item
-        dst_path = os.path.join(addon_output_dir, "server", dst_subpath)
-        filepaths_to_copy.append((src_path, dst_path))
+    for path, sub_path in find_files_in_subdir(SERVER_DIR):
+        filepaths_to_copy.append(
+            (path, os.path.join("server", sub_path))
+        )
+
+    public_dir = os.path.join(current_dir, "public")
+    for path, sub_path in find_files_in_subdir(public_dir):
+        filepaths_to_copy.append(
+            (path, os.path.join("public", sub_path))
+        )
+
+    filepaths_to_copy.extend([
+        # Copy constants needed for attributes creation
+        (
+            os.path.join(COMMON_DIR, "constants.py"),
+            os.path.join("server", "constants.py")
+        ),
+        (
+            os.path.join(current_dir, "package.py"),
+            os.path.join(addon_output_dir, "package.py")
+        )
+    ])
 
     # Copy files
     for src_path, dst_path in filepaths_to_copy:
-        safe_copy_file(src_path, dst_path)
+        if not os.path.exists(src_path):
+            continue
+        safe_copy_file(
+            src_path,
+            os.path.join(addon_output_dir, dst_path)
+        )
 
 
-def fill_client_version(current_dir):
-    version_file = os.path.join(
-        current_dir, "client", ADDON_CLIENT_DIR, "version.py"
-    )
-    with open(version_file, "w") as stream:
-        stream.write(CLIENT_VERSION_CONTENT.format(ADDON_NAME, ADDON_VERSION))
+def _get_client_files_mapping(current_dir: str):
+    client_code = os.path.join(CLIENT_DIR, ADDON_CLIENT_DIR)
+    return [
+        (src, os.path.join(ADDON_CLIENT_DIR, dst))
+        for src, dst in find_files_in_subdir(client_code)
+    ]
 
 
-def zip_client_side(addon_package_dir, current_dir, log):
-    """Copy and zip `client` content into 'addon_package_dir'.
+def zip_client_side(
+    addon_package_dir: str,
+    current_dir: str,
+    log: logging.Logger,
+    zip_basename: Optional[str] = None
+):
+    """Copy and zip `client` content into `addon_package_dir'.
 
     Args:
         addon_package_dir (str): Output package directory path.
-        current_dir (str): Directory path of addon source.
+        current_dir (str): Directoy path of addon source.
+        zip_basename (str): Output zip file name in format. 'client' by
+            default.
         log (logging.Logger): Logger object.
     """
 
-    client_dir = os.path.join(current_dir, "client")
-    client_addon_dir = os.path.join(client_dir, ADDON_CLIENT_DIR)
-    if not os.path.isdir(client_addon_dir):
-        log.info("Client directory was not found. Skipping")
-        return
-
+    if not zip_basename:
+        zip_basename = "client"
     log.info("Preparing client code zip")
-    private_dir = os.path.join(addon_package_dir, "private")
-
+    private_dir: str = os.path.join(addon_package_dir, "private")
     if not os.path.exists(private_dir):
         os.makedirs(private_dir)
 
-    zip_filepath = os.path.join(os.path.join(private_dir, "client.zip"))
-    with ZipFileLongPaths(zip_filepath, "w", zipfile.ZIP_DEFLATED) as zipf:
-        # Add client code content to zip
-        for path, sub_path in find_files_in_subdir(client_addon_dir):
-            zipf.write(path, os.path.join(ADDON_CLIENT_DIR, sub_path))
+    files_mapping: list[tuple[str, str]] = _get_client_files_mapping(
+        current_dir
+    )
+    zip_filename: str = zip_basename + ".zip"
+    zip_filepath: str = os.path.join(os.path.join(private_dir, zip_filename))
+    with ZipFileLongPaths(
+        zip_filepath, "w", zipfile.ZIP_DEFLATED
+    ) as zipf:
+        for (src_path, dst_path) in files_mapping:
+            zipf.write(src_path, dst_path)
 
-    src_pyproject = os.path.join(client_dir, "pyproject.toml")
-    shutil.copy(src_pyproject, private_dir)
+    shutil.copy(os.path.join(CLIENT_DIR, "pyproject.toml"), private_dir)
 
 
 def create_server_package(
-    current_dir: str,
     output_dir: str,
     addon_output_dir: str,
     log: logging.Logger
@@ -234,12 +276,6 @@ def create_server_package(
         output_dir, f"{ADDON_NAME}-{ADDON_VERSION}.zip"
     )
     with ZipFileLongPaths(output_path, "w", zipfile.ZIP_DEFLATED) as zipf:
-        # Write a manifest to zip
-        zipf.write(
-            os.path.join(current_dir, "package.py"),
-            "package.py"
-        )
-
         # Move addon content to zip into 'addon' directory
         addon_output_dir_offset = len(addon_output_dir) + 1
         for root, _, filenames in os.walk(addon_output_dir):
@@ -249,35 +285,81 @@ def create_server_package(
             dst_root = None
             if root != addon_output_dir:
                 dst_root = root[addon_output_dir_offset:]
-
             for filename in filenames:
                 src_path = os.path.join(root, filename)
                 dst_path = filename
                 if dst_root:
-                    dst_path = os.path.join(dst_root, filename)
+                    dst_path = os.path.join(dst_root, dst_path)
                 zipf.write(src_path, dst_path)
 
     log.info(f"Output package can be found: {output_path}")
 
 
-def main(output_dir=None, skip_zip=False, keep_sources=False):
-    log = logging.getLogger("create_package")
-    log.info("Start creating package")
+def copy_client_code(current_dir: str, output_dir: str):
+    """Copy client code to output directory.
 
-    current_dir = os.path.dirname(os.path.abspath(__file__))
+    Args:
+        current_dir (str): Directory path of addon source.
+        output_dir (str): Directory path to output client code.
+    """
+
+    if os.path.exists(output_dir):
+        shutil.rmtree(output_dir)
+
+    if os.path.exists(output_dir):
+        raise RuntimeError(
+            f"Failed to remove target folder '{output_dir}'"
+        )
+
+    os.makedirs(output_dir, exist_ok=True)
+    mapping = _get_client_files_mapping(current_dir)
+    for (src_path, dst_path) in mapping:
+        full_dst_path = os.path.join(output_dir, dst_path)
+        os.makedirs(os.path.dirname(full_dst_path), exist_ok=True)
+        shutil.copy2(src_path, full_dst_path)
+
+
+def main(
+    output_dir: Optional[str]=None,
+    skip_zip: Optional[bool]=False,
+    keep_sources: Optional[bool]=False,
+    only_client: Optional[bool]=False,
+):
+    log: logging.Logger = logging.getLogger("create_package")
+
+    current_dir: str = os.path.dirname(os.path.abspath(__file__))
     if not output_dir:
         output_dir = os.path.join(current_dir, "package")
 
-    addon_output_root = os.path.join(output_dir, ADDON_NAME)
-    addon_output_dir = os.path.join(addon_output_root, ADDON_VERSION)
-    if os.path.isdir(addon_output_dir):
-        log.info(f"Purging {addon_output_dir}")
-        shutil.rmtree(output_dir)
-    os.makedirs(addon_output_dir)
+    # Update client version file with version from 'package.py'
+    client_version_file = os.path.join(
+        current_dir, "client", ADDON_CLIENT_DIR, "version.py"
+    )
+    with open(client_version_file, "w") as stream:
+        stream.write(CLIENT_VERSION_CONTENT.format(ADDON_NAME, ADDON_VERSION))
 
-    fill_client_version(current_dir)
+    if only_client:
+        log.info("Creating client folder")
+        if not output_dir:
+            raise RuntimeError(
+                "Output directory must be defined"
+                " for client only preparation."
+            )
+        copy_client_code(current_dir, output_dir)
+        log.info("Client folder created")
+        return
+
+    log.info("Start creating package")
+
+    addon_output_root: str = os.path.join(output_dir, ADDON_NAME)
+    if os.path.isdir(addon_output_root):
+        log.info(f"Purging {addon_output_root}")
+        shutil.rmtree(addon_output_root)
 
     log.info(f"Preparing package for {ADDON_NAME}-{ADDON_VERSION}")
+    addon_output_dir: str = os.path.join(addon_output_root, ADDON_VERSION)
+    if not os.path.exists(addon_output_dir):
+        os.makedirs(addon_output_dir)
 
     copy_server_content(addon_output_dir, current_dir, log)
 
@@ -286,7 +368,7 @@ def main(output_dir=None, skip_zip=False, keep_sources=False):
     # Skip server zipping
     if not skip_zip:
         create_server_package(
-            current_dir, output_dir, addon_output_dir, log
+            output_dir, addon_output_dir, log
         )
         # Remove sources only if zip file is created
         if not keep_sources:
@@ -323,6 +405,15 @@ if __name__ == "__main__":
             " (Will be purged if already exists!)"
         )
     )
+    parser.add_argument(
+        "--only-client",
+        dest="only_client",
+        action="store_true",
+        help=(
+            "Extract only client code. This is useful for development."
+            " Requires '-o', '--output' argument to be filled."
+        )
+    )
 
     args = parser.parse_args(sys.argv[1:])
-    main(args.output_dir, args.skip_zip, args.keep_sources)
+    main(args.output_dir, args.skip_zip, args.keep_sources, args.only_client)

--- a/create_package.py
+++ b/create_package.py
@@ -22,24 +22,26 @@ client side code zipped in `private` subfolder.
 import os
 import sys
 import re
-import shutil
-import json
 import platform
+import shutil
 import argparse
 import logging
 import collections
 import zipfile
-from typing import Any, Optional, Iterable, Pattern
 
-# Name of addon
-#   - e.g. 'maya'
-ADDON_NAME: str = "version_control"
-# Name of folder where client code is located to copy 'version.py'
-#   - e.g. 'ayon_maya'
-ADDON_CLIENT_DIR: str = "ayon_version_control"
+import package
+
+ADDON_NAME: str = package.name
+ADDON_VERSION: str = package.version
+ADDON_CLIENT_DIR: str = package.client_dir
+
+CLIENT_VERSION_CONTENT = '''# -*- coding: utf-8 -*-
+"""Package declaring {} addon version."""
+__version__ = "{}"
+'''
 
 # Patterns of directories to be skipped for server part of addon
-IGNORE_DIR_PATTERNS: list[Pattern] = [
+IGNORE_DIR_PATTERNS = [
     re.compile(pattern)
     for pattern in {
         # Skip directories starting with '.'
@@ -50,7 +52,7 @@ IGNORE_DIR_PATTERNS: list[Pattern] = [
 ]
 
 # Patterns of files to be skipped for server part of addon
-IGNORE_FILE_PATTERNS: list[Pattern] = [
+IGNORE_FILE_PATTERNS = [
     re.compile(pattern)
     for pattern in {
         # Skip files starting with '.'
@@ -85,7 +87,7 @@ class ZipFileLongPaths(zipfile.ZipFile):
         )
 
 
-def safe_copy_file(src_path: str, dst_path: str):
+def safe_copy_file(src_path, dst_path):
     """Copy file and make sure destination directory exists.
 
     Ignore if destination already contains directories from source.
@@ -98,7 +100,7 @@ def safe_copy_file(src_path: str, dst_path: str):
     if src_path == dst_path:
         return
 
-    dst_dir: str = os.path.dirname(dst_path)
+    dst_dir = os.path.dirname(dst_path)
     try:
         os.makedirs(dst_dir)
     except Exception:
@@ -107,70 +109,48 @@ def safe_copy_file(src_path: str, dst_path: str):
     shutil.copy2(src_path, dst_path)
 
 
-def _value_match_regexes(value: str, regexes: Iterable[Pattern]) -> bool:
-    return any(
-        regex.search(value)
-        for regex in regexes
-    )
+def _value_match_regexes(value, regexes):
+    for regex in regexes:
+        if regex.search(value):
+            return True
+    return False
 
 
 def find_files_in_subdir(
-    src_path: str,
-    ignore_file_patterns: Optional[list[Pattern]]=None,
-    ignore_dir_patterns: Optional[list[Pattern]]=None
-) -> list[tuple[str, str]]:
-    """Find all files to copy in subdirectories of given path.
-
-    All files that match any of the patterns in 'ignore_file_patterns' will
-        be skipped and any directories that match any of the patterns in
-        'ignore_dir_patterns' will be skipped with all subfiles.
-
-    Args:
-        src_path (str): Path to directory to search in.
-        ignore_file_patterns (Optional[list[Pattern]]): List of regexes
-            to match files to ignore.
-        ignore_dir_patterns (Optional[list[Pattern]]): List of regexes
-            to match directories to ignore.
-
-    Returns:
-        list[tuple[str, str]]: List of tuples with path to file and parent
-            directories relative to 'src_path'.
-    """
-
+    src_path,
+    ignore_file_patterns=None,
+    ignore_dir_patterns=None
+):
     if ignore_file_patterns is None:
         ignore_file_patterns = IGNORE_FILE_PATTERNS
 
     if ignore_dir_patterns is None:
         ignore_dir_patterns = IGNORE_DIR_PATTERNS
-    output: list[tuple[str, str]] = []
+    output = []
 
-    hierarchy_queue: collections.deque = collections.deque()
+    hierarchy_queue = collections.deque()
     hierarchy_queue.append((src_path, []))
     while hierarchy_queue:
-        item: tuple[str, str] = hierarchy_queue.popleft()
+        item = hierarchy_queue.popleft()
         dirpath, parents = item
         for name in os.listdir(dirpath):
-            path: str = os.path.join(dirpath, name)
+            path = os.path.join(dirpath, name)
             if os.path.isfile(path):
                 if not _value_match_regexes(name, ignore_file_patterns):
-                    items: list[str] = list(parents)
+                    items = list(parents)
                     items.append(name)
                     output.append((path, os.path.sep.join(items)))
                 continue
 
             if not _value_match_regexes(name, ignore_dir_patterns):
-                items: list[str] = list(parents)
+                items = list(parents)
                 items.append(name)
                 hierarchy_queue.append((path, items))
 
     return output
 
 
-def copy_server_content(
-    addon_output_dir: str,
-    current_dir: str,
-    log: logging.Logger
-):
+def copy_server_content(addon_output_dir, current_dir, log):
     """Copies server side folders to 'addon_package_dir'
 
     Args:
@@ -181,17 +161,12 @@ def copy_server_content(
 
     log.info("Copying server content")
 
-    filepaths_to_copy: list[tuple[str, str]] = []
-    server_dirpath: str = os.path.join(current_dir, "server")
-
-    # Version
-    src_version_path: str = os.path.join(current_dir, "version.py")
-    dst_version_path: str = os.path.join(addon_output_dir, "version.py")
-    filepaths_to_copy.append((src_version_path, dst_version_path))
+    filepaths_to_copy = []
+    server_dirpath = os.path.join(current_dir, "server")
 
     for item in find_files_in_subdir(server_dirpath):
         src_path, dst_subpath = item
-        dst_path: str = os.path.join(addon_output_dir, dst_subpath)
+        dst_path = os.path.join(addon_output_dir, "server", dst_subpath)
         filepaths_to_copy.append((src_path, dst_path))
 
     # Copy files
@@ -199,11 +174,15 @@ def copy_server_content(
         safe_copy_file(src_path, dst_path)
 
 
-def zip_client_side(
-    addon_package_dir: str,
-    current_dir: str,
-    log: logging.Logger
-):
+def fill_client_version(current_dir):
+    version_file = os.path.join(
+        current_dir, "client", ADDON_CLIENT_DIR, "version.py"
+    )
+    with open(version_file, "w") as stream:
+        stream.write(CLIENT_VERSION_CONTENT.format(ADDON_NAME, ADDON_VERSION))
+
+
+def zip_client_side(addon_package_dir, current_dir, log):
     """Copy and zip `client` content into 'addon_package_dir'.
 
     Args:
@@ -212,34 +191,32 @@ def zip_client_side(
         log (logging.Logger): Logger object.
     """
 
-    client_dir: str = os.path.join(current_dir, "client")
-    if not os.path.isdir(client_dir):
+    client_dir = os.path.join(current_dir, "client")
+    client_addon_dir = os.path.join(client_dir, ADDON_CLIENT_DIR)
+    if not os.path.isdir(client_addon_dir):
         log.info("Client directory was not found. Skipping")
         return
 
     log.info("Preparing client code zip")
-    private_dir: str = os.path.join(addon_package_dir, "private")
+    private_dir = os.path.join(addon_package_dir, "private")
 
     if not os.path.exists(private_dir):
         os.makedirs(private_dir)
 
-    src_version_path: str = os.path.join(current_dir, "version.py")
-    dst_version_path: str = os.path.join(ADDON_CLIENT_DIR, "version.py")
-
-    zip_filepath: str = os.path.join(os.path.join(private_dir, "client.zip"))
+    zip_filepath = os.path.join(os.path.join(private_dir, "client.zip"))
     with ZipFileLongPaths(zip_filepath, "w", zipfile.ZIP_DEFLATED) as zipf:
         # Add client code content to zip
-        for path, sub_path in find_files_in_subdir(client_dir):
-            zipf.write(path, sub_path)
+        for path, sub_path in find_files_in_subdir(client_addon_dir):
+            zipf.write(path, os.path.join(ADDON_CLIENT_DIR, sub_path))
 
-        # Add 'version.py' to client code
-        zipf.write(src_version_path, dst_version_path)
+    src_pyproject = os.path.join(client_dir, "pyproject.toml")
+    shutil.copy(src_pyproject, private_dir)
 
 
 def create_server_package(
+    current_dir: str,
     output_dir: str,
     addon_output_dir: str,
-    addon_version: str,
     log: logging.Logger
 ):
     """Create server package zip file.
@@ -249,21 +226,19 @@ def create_server_package(
     Args:
         output_dir (str): Directory path to output zip file.
         addon_output_dir (str): Directory path to addon output directory.
-        addon_version (str): Version of addon.
         log (logging.Logger): Logger object.
     """
 
     log.info("Creating server package")
     output_path = os.path.join(
-        output_dir, f"{ADDON_NAME}-{addon_version}.zip"
+        output_dir, f"{ADDON_NAME}-{ADDON_VERSION}.zip"
     )
-    manifest_data: dict[str, str] = {
-        "addon_name": ADDON_NAME,
-        "addon_version": addon_version
-    }
     with ZipFileLongPaths(output_path, "w", zipfile.ZIP_DEFLATED) as zipf:
         # Write a manifest to zip
-        zipf.writestr("manifest.json", json.dumps(manifest_data, indent=4))
+        zipf.write(
+            os.path.join(current_dir, "package.py"),
+            "package.py"
+        )
 
         # Move addon content to zip into 'addon' directory
         addon_output_dir_offset = len(addon_output_dir) + 1
@@ -271,49 +246,38 @@ def create_server_package(
             if not filenames:
                 continue
 
-            dst_root = "addon"
+            dst_root = None
             if root != addon_output_dir:
-                dst_root = os.path.join(
-                    dst_root, root[addon_output_dir_offset:]
-                )
+                dst_root = root[addon_output_dir_offset:]
+
             for filename in filenames:
                 src_path = os.path.join(root, filename)
-                dst_path = os.path.join(dst_root, filename)
+                dst_path = filename
+                if dst_root:
+                    dst_path = os.path.join(dst_root, filename)
                 zipf.write(src_path, dst_path)
 
     log.info(f"Output package can be found: {output_path}")
 
 
-def main(
-    output_dir: Optional[str]=None,
-    skip_zip: Optional[bool]=False,
-    keep_sources: Optional[bool]=False
-):
-    log: logging.Logger = logging.getLogger("create_package")
+def main(output_dir=None, skip_zip=False, keep_sources=False):
+    log = logging.getLogger("create_package")
     log.info("Start creating package")
 
-    current_dir: str = os.path.dirname(os.path.abspath(__file__))
+    current_dir = os.path.dirname(os.path.abspath(__file__))
     if not output_dir:
         output_dir = os.path.join(current_dir, "package")
 
-    version_filepath: str = os.path.join(current_dir, "version.py")
-    version_content: dict[str, Any] = {}
-    with open(version_filepath, "r") as stream:
-        exec(stream.read(), version_content)
-    addon_version: str = version_content["__version__"]
-
-    addon_output_root: str = os.path.join(output_dir, ADDON_NAME)
-    addon_output_dir: str = os.path.join(
-        addon_output_root, addon_version
-    )
+    addon_output_root = os.path.join(output_dir, ADDON_NAME)
+    addon_output_dir = os.path.join(addon_output_root, ADDON_VERSION)
     if os.path.isdir(addon_output_dir):
         log.info(f"Purging {addon_output_dir}")
         shutil.rmtree(output_dir)
+    os.makedirs(addon_output_dir)
 
-    log.info(f"Preparing package for {ADDON_NAME}-{addon_version}")
+    fill_client_version(current_dir)
 
-    if not os.path.exists(addon_output_dir):
-        os.makedirs(addon_output_dir)
+    log.info(f"Preparing package for {ADDON_NAME}-{ADDON_VERSION}")
 
     copy_server_content(addon_output_dir, current_dir, log)
 
@@ -322,7 +286,7 @@ def main(
     # Skip server zipping
     if not skip_zip:
         create_server_package(
-            output_dir, addon_output_dir, addon_version, log
+            current_dir, output_dir, addon_output_dir, log
         )
         # Remove sources only if zip file is created
         if not keep_sources:
@@ -359,16 +323,6 @@ if __name__ == "__main__":
             " (Will be purged if already exists!)"
         )
     )
-    parser.add_argument(
-        "--debug",
-        dest="debug",
-        action="store_true",
-        help="Debug log messages."
-    )
 
     args = parser.parse_args(sys.argv[1:])
-    level = logging.INFO
-    if args.debug:
-        level = logging.DEBUG
-    logging.basicConfig(level=level)
     main(args.output_dir, args.skip_zip, args.keep_sources)

--- a/package.py
+++ b/package.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+"""Package declaring addon version."""
+name = "version_control"
+title = "Version Control"
+version = "0.0.2"
+client_dir = "version_control"

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -3,13 +3,9 @@
 from ayon_server.addons import BaseServerAddon
 
 from .settings import VersionControlSettings, DEFAULT_VALUES
-from .version import __version__
 
 
 class VersionControlAddon(BaseServerAddon):
-    name = "version_control"
-    title = "Version Control"
-    version = __version__
     #settings_model: Type[VersionControlSettings] = VersionControlSettings
     settings_model = VersionControlSettings
 

--- a/version.py
+++ b/version.py
@@ -1,3 +1,0 @@
-# -*- coding: utf-8 -*-
-"""Package declaring addon version."""
-__version__ = "0.0.1"


### PR DESCRIPTION
**Problem**

`create_package.py` was not copying `pyproject.toml` with dependencies along the zip file so [ayon-dependencies-tool](https://github.com/ynput/ayon-dependencies-tool) couldn't find it.

**Testing**
- Create package, upload it to server, use it in a bundle, run [ayon-dependencies-tool](https://github.com/ynput/ayon-dependencies-tool) and get p4 dependency into your dependency package.