### PR TITLE
Removed click import

### DIFF
--- a/client/version_control/addon.py
+++ b/client/version_control/addon.py
@@ -1,4 +1,3 @@
-import click
 import os
 
 from ayon_core.addon import AYONAddon, ITrayService, IPluginPaths
@@ -141,8 +140,3 @@ class VersionControlAddon(AYONAddon, ITrayService, IPluginPaths):
 
         return os.path.join(VERSION_CONTROL_ADDON_DIR, "launch_hooks",
                             self.active_version_control_system)
-
-
-@click.group("version_control", help="Version Control module related commands.")
-def cli_main():
-    pass

--- a/client/version_control/addon.py
+++ b/client/version_control/addon.py
@@ -116,9 +116,6 @@ class VersionControlAddon(AYONAddon, ITrayService, IPluginPaths):
             self.webserver = WebServer()
             self.webserver.start()
 
-    def cli(self, click_group):
-        click_group.add_command(cli_main)
-
     def get_plugin_paths(self):
         return {}
 

--- a/client/version_control/plugins/publish/validate_stream.py
+++ b/client/version_control/plugins/publish/validate_stream.py
@@ -1,7 +1,7 @@
 import pyblish.api
 
 from ayon_core.pipeline.publish import ValidateContentsOrder
-from ayon_core.pipeline import PublishXmlValidationError
+from ayon_core.pipeline.publish import PublishValidationError
 
 
 class ValidateStream(pyblish.api.InstancePlugin):
@@ -25,4 +25,4 @@ class ValidateStream(pyblish.api.InstancePlugin):
                 "Please let your Perforce admin set up your workspace with "
                 "stream connected."
             )
-            raise PublishXmlValidationError(self, msg)
+            raise PublishValidationError(self, msg)


### PR DESCRIPTION
## Changelog Description
click is now only runtime dependency, not found in Unreal. It was actually not important here.


## Additional info
It was resulting in autocreator for changelist being not picked up. 


## Testing notes:

1. open Publisher in Unreal
2. there should be changelist instance present
