### PR TITLE
Enable/disable version control addon on project

### DIFF
--- a/client/version_control/__init__.py
+++ b/client/version_control/__init__.py
@@ -1,11 +1,14 @@
 """
 Package for interfacing with version control systems
 """
-
-from .addon import VERSION_CONTROL_ADDON_DIR
-from .addon import VersionControlAddon
+from .addon import (
+    VersionControlAddon,
+    is_version_control_enabled,
+    VERSION_CONTROL_ADDON_DIR
+)
 
 __all__ = (
     "VersionControlAddon",
+    "is_version_control_enabled",
     "VERSION_CONTROL_ADDON_DIR",
 )

--- a/client/version_control/addon.py
+++ b/client/version_control/addon.py
@@ -137,3 +137,7 @@ class VersionControlAddon(AYONAddon, ITrayService, IPluginPaths):
 
         return os.path.join(VERSION_CONTROL_ADDON_DIR, "launch_hooks",
                             self.active_version_control_system)
+
+
+def is_version_control_enabled(project_settings):
+    return project_settings.get("version_control", {}).get("enabled", False)

--- a/client/version_control/launch_hooks/perforce/pre_load_sync_project.py
+++ b/client/version_control/launch_hooks/perforce/pre_load_sync_project.py
@@ -72,8 +72,10 @@ class SyncUnrealProject(PreLaunchHook):
 
     def _get_enabled_version_control_addon(self):
         manager = AddonsManager()
-        version_control_addon = manager.get("version_control")
-        if version_control_addon and version_control_addon.enabled:
+        version_control_addon = manager["version_control"]
+        proj_settings = self.data["project_settings"]
+        project_enabled = proj_settings["version_control"]["enabled"]
+        if project_enabled:
             return version_control_addon
         return None
 

--- a/client/version_control/launch_hooks/perforce/pre_load_sync_project.py
+++ b/client/version_control/launch_hooks/perforce/pre_load_sync_project.py
@@ -19,6 +19,7 @@ from ayon_core.tools.utils import qt_app_context
 from ayon_core.addon import AddonsManager
 
 from version_control.changes_viewer import ChangesWindows
+from version_control import is_version_control_enabled
 
 
 class SyncUnrealProject(PreLaunchHook):
@@ -71,12 +72,9 @@ class SyncUnrealProject(PreLaunchHook):
         return project_files[0]
 
     def _get_enabled_version_control_addon(self):
-        manager = AddonsManager()
-        version_control_addon = manager["version_control"]
-        proj_settings = self.data["project_settings"]
-        project_enabled = proj_settings["version_control"]["enabled"]
-        if project_enabled:
-            return version_control_addon
+        if is_version_control_enabled(self.data["project_settings"]):
+            manager = AddonsManager()
+            return manager["version_control"]
         return None
 
     def _find_uproject_files(self, start_dir):

--- a/client/version_control/plugins/publish/collect_version_control_login.py
+++ b/client/version_control/plugins/publish/collect_version_control_login.py
@@ -20,10 +20,11 @@ class CollectVersionControlLogin(pyblish.api.ContextPlugin):
     order = pyblish.api.CollectorOrder + 0.4990
     targets = ["local"]
 
-
     def process(self, context):
         version_control = AddonsManager().get("version_control")
-        if not version_control or not version_control.enabled:
+        project_name = context.data["projectName"]
+        project_settings = context.data["project_settings"]
+        if not self._is_addon_enabled(version_control, project_settings):
             self.log.info("No version control enabled")
             return
 
@@ -41,3 +42,17 @@ class CollectVersionControlLogin(pyblish.api.ContextPlugin):
 
         stream = PerforceRestStub.get_stream(conn_info["workspace_dir"])
         context.data["version_control"]["stream"] = stream
+        self.log.debug(f"stream::{stream}")
+
+    def _is_addon_enabled(self, version_control, project_settings):
+        """Check if addon is enabled for this project.
+
+        Args:
+            version_control Union[AYONAddon, Any]: addon returned from manager
+            project_settings (Dict[str, Any]): Prepared project settings.
+
+        Returns
+            (bool)
+        """
+        project_enabled = project_settings[version_control.name]["enabled"]
+        return version_control and version_control.enabled and project_enabled

--- a/client/version_control/plugins/publish/collect_version_control_login.py
+++ b/client/version_control/plugins/publish/collect_version_control_login.py
@@ -27,7 +27,10 @@ class CollectVersionControlLogin(pyblish.api.ContextPlugin):
         project_name = context.data["projectName"]
         project_settings = context.data["project_settings"]
         if not self._is_addon_enabled(version_control, project_settings):
-            self.log.info("No version control enabled")
+            self.log.info(
+                "Version control addon is not enabled"
+                f" for project '{project_name}'"
+            )
             return
 
         conn_info = self._get_conn_info(
@@ -50,11 +53,11 @@ class CollectVersionControlLogin(pyblish.api.ContextPlugin):
         """Check if addon is enabled for this project.
 
         Args:
-            version_control Union[AYONAddon, Any]: addon returned from manager
+            version_control (AYONAddon): Version control addon from manager.
             project_settings (Dict[str, Any]): Prepared project settings.
 
         Returns
-            (bool)
+            bool: Addon is enabled or not.
         """
         project_enabled = project_settings[version_control.name]["enabled"]
         return version_control and version_control.enabled and project_enabled
@@ -68,7 +71,7 @@ class CollectVersionControlLogin(pyblish.api.ContextPlugin):
             project_settings (Dict[str, Any]): Prepared project settings.
 
         Returns:
-            (dict)
+            dict[str, str]: Connection info.
 
         Raises:
             (PublishError): When credentials are missing.

--- a/client/version_control/plugins/publish/collect_version_control_login.py
+++ b/client/version_control/plugins/publish/collect_version_control_login.py
@@ -13,6 +13,7 @@ from ayon_core.pipeline.publish import PublishError
 from ayon_common.utils import get_local_site_id
 
 from version_control.rest.perforce.rest_stub import PerforceRestStub
+from version_control import is_version_control_enabled
 
 
 class CollectVersionControlLogin(pyblish.api.ContextPlugin):
@@ -26,7 +27,7 @@ class CollectVersionControlLogin(pyblish.api.ContextPlugin):
         version_control = AddonsManager().get("version_control")
         project_name = context.data["projectName"]
         project_settings = context.data["project_settings"]
-        if not self._is_addon_enabled(version_control, project_settings):
+        if not is_version_control_enabled(project_settings):
             self.log.info(
                 "Version control addon is not enabled"
                 f" for project '{project_name}'"

--- a/client/version_control/plugins/publish/collect_version_control_login.py
+++ b/client/version_control/plugins/publish/collect_version_control_login.py
@@ -9,7 +9,7 @@ Provides:
 import pyblish.api
 
 from ayon_core.addon import AddonsManager
-from ayon_core.pipeline.publish import PublishValidationError
+from ayon_core.pipeline.publish import PublishError
 from ayon_common.utils import get_local_site_id
 
 from version_control.rest.perforce.rest_stub import PerforceRestStub
@@ -71,7 +71,7 @@ class CollectVersionControlLogin(pyblish.api.ContextPlugin):
             (dict)
 
         Raises:
-            (PublishValidationError): if missing credentials
+            (PublishError): When credentials are missing.
         """
         conn_info = version_control.get_connection_info(
             project_name, project_settings)
@@ -82,14 +82,19 @@ class CollectVersionControlLogin(pyblish.api.ContextPlugin):
             conn_info["workspace_dir"]
         ]):
             site_name = get_local_site_id()
-            sett_str = f"ayon+settings://version_control?project= {project_name}&site={site_name}"  # noqa
-            raise PublishValidationError(
+            sett_str = (
+                f"ayon+settings://version_control?project= {project_name}&"
+                f"site={site_name}"
+            )
+            raise PublishError(
                 "Required credentials are missing. "
                 f"Please go to `{sett_str}` to fill it.")
 
         if not all([conn_info["host"], conn_info["port"]]):
-            sett_str = f"ayon+settings://version_control?project={project_name}"  # noqa
-            raise PublishValidationError(
+            sett_str = (
+                f"ayon+settings://version_control?project={project_name}"
+            )
+            raise PublishError(
                 "Required version control settings are missing. "
                 f"Please ask your AYON admin to fill `{sett_str}`.")
 

--- a/client/version_control/plugins/publish/collect_version_control_login.py
+++ b/client/version_control/plugins/publish/collect_version_control_login.py
@@ -60,7 +60,7 @@ class CollectVersionControlLogin(pyblish.api.ContextPlugin):
             bool: Addon is enabled or not.
         """
         project_enabled = project_settings[version_control.name]["enabled"]
-        return version_control and version_control.enabled and project_enabled
+        return version_control and project_enabled
 
     def _get_conn_info(self, project_name, version_control, project_settings):
         """Gets and check credentials for version-control

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -67,7 +67,7 @@ class LocalSubmodel(BaseSettingsModel):
 class VersionControlSettings(BaseSettingsModel):
     """Version Control Project Settings."""
 
-    enabled: bool = Field(default=True)
+    enabled: bool = Field(default=False)
 
     active_version_control_system: str = Field(
         '',

--- a/server/settings/main.py
+++ b/server/settings/main.py
@@ -70,7 +70,7 @@ class VersionControlSettings(BaseSettingsModel):
     enabled: bool = Field(default=False)
 
     active_version_control_system: str = Field(
-        '',
+        "",
         enum_resolver=backend_enum,
         title="Backend name"
     )


### PR DESCRIPTION
## Changelog Description
`version-control` is now by default disabled in all projects, could be enabled per project. 
![image](https://github.com/user-attachments/assets/b06a090e-1f56-4e36-8f0d-4ef190867150)


## Additional info
This should alleviate concerns about using it in production bundle where it is necessary because of Site Settings.
Current implementation is that IF addon is globally disabled in `Studio Settings` it IS DISABLED for all projects.


## Testing notes:

1. experiment with enabling/disabling per project
2. play with missing username/port
