### PR TITLE
Respect local workspace and depots when retrieving changelists

### DIFF
--- a/client/version_control/backends/perforce/api/__init__.py
+++ b/client/version_control/backends/perforce/api/__init__.py
@@ -1225,13 +1225,6 @@ class P4ConnectionManager:
         client["Stream"] = stream
         return self.p4.save_client(client)
 
-    # def _connect_get_client_spec(self, client: str = None):
-    #     cmd = ["client", "-o"]
-    #     if client:
-    #         cmd.append(client)
-    #     client_spec = self._connect_run_command(*cmd)
-    #     return client_spec
-
     def _connect_delete(
         self,
         path: T_PthStrLst,

--- a/client/version_control/backends/perforce/api/__init__.py
+++ b/client/version_control/backends/perforce/api/__init__.py
@@ -1185,9 +1185,15 @@ class P4ConnectionManager:
 
         return result
 
-    def _connect_get_changes(self):
-        change_list = self._connect_run_command("changes",
-                                                "-s", "submitted")
+    def _connect_get_changes(self, stream=None):
+        client_info = self.p4.run("client", "-o")[0]
+        stream = stream or client_info["Stream"]
+
+        cmd = ["changes", "-s", "submitted"]
+        if stream:
+            cmd.append(f"{stream}/...")
+
+        change_list = self._connect_run_command(*cmd)
         if not change_list:
             return
 

--- a/client/version_control/backends/perforce/api/__init__.py
+++ b/client/version_control/backends/perforce/api/__init__.py
@@ -1201,9 +1201,10 @@ class P4ConnectionManager:
         return change_list
 
     def _connect_get_last_change_list(self):
-        change_list = self._connect_run_command("changes",
-                                                "-s", "submitted",
-                                                "-m", 1)
+        client_info = self.p4.run("client", "-o")[0]
+        client = client_info["Client"]
+        cmd = ["changes", "-s", "submitted", "-m", 1, "-c", client]
+        change_list = self._connect_run_command(*cmd)
         if not change_list:
             return
 
@@ -1223,6 +1224,13 @@ class P4ConnectionManager:
         client["Root"] = root
         client["Stream"] = stream
         return self.p4.save_client(client)
+
+    # def _connect_get_client_spec(self, client: str = None):
+    #     cmd = ["client", "-o"]
+    #     if client:
+    #         cmd.append(client)
+    #     client_spec = self._connect_run_command(*cmd)
+    #     return client_spec
 
     def _connect_delete(
         self,

--- a/client/version_control/backends/perforce/backend.py
+++ b/client/version_control/backends/perforce/backend.py
@@ -95,9 +95,9 @@ class VersionControlPerforce(abstract.VersionControl):
         return api.move(path, new_path, change_description=change_description)
 
     @staticmethod
-    def get_changes():
+    def get_changes(stream=None):
         # type: (None) -> (list(dict)) | None
-        return api.get_changes()
+        return api.get_changes(stream=stream)
 
     @staticmethod
     def get_existing_change_list(comment):

--- a/client/version_control/backends/perforce/rest_routes.py
+++ b/client/version_control/backends/perforce/rest_routes.py
@@ -149,7 +149,8 @@ class GetChanges(PerforceRestApiEndpoint):
         log.debug("GetChanges called")
         content = await request.json()
 
-        result = VersionControlPerforce.get_changes()
+        stream = content.get("stream")
+        result = VersionControlPerforce.get_changes(stream=stream)
         return Response(
             status=200,
             body=self.encode(result),


### PR DESCRIPTION
## Changelog Description
- gets latest available changelist from the workspace currently in use
  - was getting the latest changelist from all users across all depots which can cause issue during submission as it might pick up a changelist that the user submitting didn't submit to p4 which effectively would render a different users changelist
- gets all available changelists to sync to in `ChangelistViewer` from the current depot
  - old behaviour was to get all available changelists across all depots