### PR TITLE
Perforce trigger to spawn AYON events

### DIFF
--- a/client/version_control/perforce_triggers/README.md
+++ b/client/version_control/perforce_triggers/README.md
@@ -1,0 +1,22 @@
+Perforce trigger
+================
+
+This trigger(s) provides connection between Perforce and AYON server.
+
+Currently it is implemented "submit-change" trigger which engages before any commit. 
+This should result in calling specific endpoint on AYON server which will create
+event from provided submit information (user, changelist, client).
+
+This event might be later consumed and start AYON based automatization.
+
+Attached script must be committed to Perforce depot which should be observed AND
+trigger created by perforce user with admin permissions via `p4 triggers`.
+
+Format of added trigger description (at the bottom of shown form, tab at beginning of line):
+```
+	ayon_change_submit change-submit //streamsDepot/... "python3 %//streamsDepot/mainline/Triggers/change_submit_trigger.py% %change% %user% %client%"
+```
+where `streamsDepot` is name of observed Perforce depot, `//streamsDepot/mainline/Triggers` is path
+where `change_submit_trigger.py` is committed.
+
+(Requires `python3` available on Perforce server machine.)

--- a/client/version_control/perforce_triggers/change_submit_trigger.py
+++ b/client/version_control/perforce_triggers/change_submit_trigger.py
@@ -34,25 +34,19 @@ def get_json_response_data(url, headers):
 
 
 def get_addon_version():
-    url = f"{AYON_SERVER_URL}/api/bundles"
-    bundle_data = get_json_response_data(url, headers)
+    """Looks for latest version of ADDON_NAME"""
+    url = f"{AYON_SERVER_URL}/api/addons?details=1"
+    data = get_json_response_data(url, headers)
 
-    production_bundle_name = bundle_data["productionBundle"]
-    bundle_addons = None
-    for bundle in bundle_data["bundles"]:
-        if bundle["name"] == production_bundle_name:
-            bundle_addons = bundle["addons"]
+    found_addon = None
+    for addon in data["addons"]:
+        if addon["name"] == ADDON_NAME:
+            found_addon = addon
             break
-    if not bundle_addons:
-        print(f"Cannot find {production_bundle_name}")
-        return 1
 
-    bundle_version = bundle_addons.get(ADDON_NAME)
-    if not bundle_version:
-        print(
-            f"{ADDON_NAME} not installed in {production_bundle_name}")
+    if not found_addon:
+        print(f"'{ADDON_NAME} is not installed on the server.")
         return 1
-    return bundle_version
 
 
 def call_change_submit_endpoint(

--- a/client/version_control/perforce_triggers/change_submit_trigger.py
+++ b/client/version_control/perforce_triggers/change_submit_trigger.py
@@ -1,0 +1,109 @@
+import urllib.request
+import json
+import os
+import sys
+import datetime
+
+AYON_SERVER_URL = os.environ.get("AYON_SERVER_URL")
+AYON_API_KEY = os.environ.get("AYON_API_KEY")
+
+if not all(AYON_SERVER_URL, AYON_API_KEY):
+    raise ValueError("Both AYON_SERVER_URL and AYON_API_KEY env vars "
+                     "must be set")
+
+ADDON_NAME = "version_control"
+
+headers = {
+    'x-api-key': AYON_API_KEY,
+    'Content-Type': 'application/json',  # Optional: Specify content type if needed
+}
+
+
+def get_json_response_data(url, headers):
+    global data
+
+    req = urllib.request.Request(url, headers=headers)
+    # Make a GET request
+    with urllib.request.urlopen(req) as response:
+        # Read and decode the response data
+        data = response.read().decode()
+
+        ret_code = response.getcode()
+        if ret_code != 200:
+            raise ValueError(f"Call failed:{ret_code}")
+
+        # Optionally, parse JSON data if applicable
+        try:
+            return json.loads(data)
+
+        except json.JSONDecodeError:
+            print("Response is not in JSON format.")
+
+
+def get_addon_version():
+    # Define the URL
+    url = f"{AYON_SERVER_URL}/api/bundles"
+    bundle_data = get_json_response_data(url, headers)
+
+    production_bundle_name = bundle_data["productionBundle"]
+    bundle_addons = None
+    for bundle in bundle_data["bundles"]:
+        if bundle["name"] == production_bundle_name:
+            bundle_addons = bundle["addons"]
+            break
+    if not bundle_addons:
+        raise ValueError(f"Cannot find {production_bundle_name}")
+
+    bundle_version = bundle_addons.get(ADDON_NAME)
+    if not bundle_version:
+        raise ValueError(
+            f"{ADDON_NAME} not installed in {production_bundle_name}")
+    return bundle_version
+
+
+def call_change_submit_endpoint(
+        addon_name, addon_version, user, changelist, client):
+    url = f"{AYON_SERVER_URL}/api/addons/{addon_name}/{addon_version}/change_submit"
+
+    payload = {
+        "user": user,
+        "changelist": changelist,
+        "client": client
+    }
+    json_data = json.dumps(payload).encode('utf-8')
+
+    req = urllib.request.Request(url, data=json_data, headers=headers)
+    req.add_header('Content-Type', 'application/json; charset=utf-8')
+
+    # Send the request and get the response
+    with urllib.request.urlopen(req) as response:
+        response_body = response.read().decode()  # Read and decode the
+        print(response_body)
+
+
+def log_to_file(message):
+    with open("/tmp/trigger.log", "a") as log_file:
+        log_file.write(f"{datetime.datetime.now()}: {message}\n")
+
+
+def main():
+    if len(sys.argv) < 4:
+        log_to_file("Error: Not enough arguments provided.")
+        return 1
+
+    changelist_id = sys.argv[1]  # %change%
+    user = sys.argv[2]   # %user%
+    client = sys.argv[3]  # %client%
+
+    # Log the changelist submission details
+    log_to_file(f"Changelist {changelist_id} submitted by {user}")
+
+    addon_version = get_addon_version()
+    call_change_submit_endpoint(
+        ADDON_NAME, addon_version, user, changelist_id, client)
+
+    return 0  # Return 0 to indicate success
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/client/version_control/perforce_triggers/change_submit_trigger.py
+++ b/client/version_control/perforce_triggers/change_submit_trigger.py
@@ -48,6 +48,8 @@ def get_addon_version():
         print(f"'{ADDON_NAME} is not installed on the server.")
         return 1
 
+    return list(found_addon["versions"].keys())[-1]
+
 
 def call_change_submit_endpoint(
         addon_name, addon_version, user, changelist, client, stream):

--- a/client/version_control/perforce_triggers/change_submit_trigger.py
+++ b/client/version_control/perforce_triggers/change_submit_trigger.py
@@ -50,7 +50,7 @@ def get_addon_version():
 
 
 def call_change_submit_endpoint(
-        addon_name, addon_version, user, changelist, client):
+        addon_name, addon_version, user, changelist, client, stream):
     """Calls endpoint on AYON server to spawn event per submit"""
     url = f"{AYON_SERVER_URL}/api/addons/{addon_name}/{addon_version}/change_submit"
 
@@ -58,7 +58,8 @@ def call_change_submit_endpoint(
         "payload_schema_version": PAYLOAD_SCHEMA_VERSION,
         "user": user,
         "changelist": changelist,
-        "client": client
+        "client": client,
+        "stream": stream
     }
     json_data = json.dumps(payload).encode('utf-8')
 
@@ -72,26 +73,27 @@ def call_change_submit_endpoint(
 
 
 def main():
-    if len(sys.argv) < 4:
+    if len(sys.argv) < 5:
         print("Error: Not enough arguments provided. "
-                    "Expected arguments %change% %user% %client%")
+              "Expected arguments %change% %user% %client% %stream%")
         return 1
 
     if not all([AYON_SERVER_URL, AYON_API_KEY]):
         print("Both AYON_SERVER_URL and AYON_API_KEY constants "
-                    "must be set")
+              "must be set")
         return 1
 
     changelist_id = sys.argv[1]  # %change%
     user = sys.argv[2]   # %user%
     client = sys.argv[3]  # %client%
+    stream = sys.argv[4]  # %stream%
 
     # Log the changelist submission details
-    print(f"Changelist {changelist_id} submitted by {user}")
+    print(f"Changelist {changelist_id} submitted by {user} in {stream}")
 
     addon_version = get_addon_version()
     call_change_submit_endpoint(
-        ADDON_NAME, addon_version, user, changelist_id, client)
+        ADDON_NAME, addon_version, user, changelist_id, client, stream)
 
     return 0  # Return 0 to indicate success
 

--- a/client/version_control/perforce_triggers/change_submit_trigger.py
+++ b/client/version_control/perforce_triggers/change_submit_trigger.py
@@ -7,6 +7,9 @@ AYON_API_KEY = ""  # SET HERE!
 
 ADDON_NAME = "version_control"
 
+TRIGGER_SCRIPT_VERSION = "0.1.0"
+PAYLOAD_SCHEMA_VERSION = "0.1.0"
+
 headers = {
     'x-api-key': AYON_API_KEY,
     'Content-Type': 'application/json',
@@ -54,9 +57,11 @@ def get_addon_version():
 
 def call_change_submit_endpoint(
         addon_name, addon_version, user, changelist, client):
+    """Calls endpoint on AYON server to spawn event per submit"""
     url = f"{AYON_SERVER_URL}/api/addons/{addon_name}/{addon_version}/change_submit"
 
     payload = {
+        "payload_schema_version": PAYLOAD_SCHEMA_VERSION,
         "user": user,
         "changelist": changelist,
         "client": client

--- a/client/version_control/version.py
+++ b/client/version_control/version.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
 """Package declaring AYON addon 'version_control' version."""
-__version__ = "0.1.0+dev"
+__version__ = "0.1.0+dev.1"

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,15 +1,56 @@
-#from typing import Type
+from fastapi import Response
 
 from ayon_server.addons import BaseServerAddon
+from ayon_server.events import dispatch_event
 
 from .settings import VersionControlSettings, DEFAULT_VALUES
+
+from ayon_server.types import Field, OPModel
+
+class ChangeSubmitModel(OPModel):
+    user: str
+    changelist: int
+    client: str
 
 
 class VersionControlAddon(BaseServerAddon):
     #settings_model: Type[VersionControlSettings] = VersionControlSettings
     settings_model = VersionControlSettings
 
+    def initialize(self) -> None:
+
+        self.add_endpoint(
+            "/change_submit",
+            self.change_submit,
+            method="POST",
+        )
 
     async def get_default_settings(self):
         settings_model_cls = self.get_settings_model()
         return settings_model_cls(**DEFAULT_VALUES)
+
+    async def change_submit(
+        self,
+        post_data: ChangeSubmitModel,
+    ) -> Response:
+
+        topic = "perforce.change_submit"
+
+        payload = {
+            "perforce_user": post_data.user,
+            "changelist": post_data.changelist,
+            "client": post_data.client
+        }
+        try:
+            await dispatch_event(
+                topic,
+                description=f"{post_data.user} "
+                            f"commited {post_data.changelist}",
+                payload=payload,
+            )
+        except Exception:
+            m = f"Unable to dispatch commit info"
+            # do not use the logger, if you don't like recursion
+            print(m, flush=True)
+
+        return Response(status_code=204)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -14,7 +14,6 @@ class ChangeSubmitModel(OPModel):
 
 
 class VersionControlAddon(BaseServerAddon):
-    #settings_model: Type[VersionControlSettings] = VersionControlSettings
     settings_model = VersionControlSettings
 
     def initialize(self) -> None:

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -8,9 +8,11 @@ from .settings import VersionControlSettings, DEFAULT_VALUES
 from ayon_server.types import Field, OPModel
 
 class ChangeSubmitModel(OPModel):
+    payload_schema_version: str
     user: str
     changelist: int
     client: str
+    stream: str
 
 
 class VersionControlAddon(BaseServerAddon):
@@ -38,13 +40,15 @@ class VersionControlAddon(BaseServerAddon):
         payload = {
             "perforce_user": post_data.user,
             "changelist": post_data.changelist,
-            "client": post_data.client
+            "client": post_data.client,
+            "stream": post_data.stream
         }
         try:
             await dispatch_event(
                 topic,
                 description=f"{post_data.user} "
-                            f"commited {post_data.changelist}",
+                            f"commited {post_data.changelist} in "
+                            f"{post_data.stream}",
                 payload=payload,
             )
         except Exception:


### PR DESCRIPTION
## Changelog Description
This PR adds possibility for connection between Perforce and AYON servers via P4 Triggers. This allows future automatization when some logic could trigger based on p4 commit.

This requires to deploy (commit) `ayon-version-control/client/version_control/perforce_triggers/change_submit_trigger.py` to P4 depot you want to monitor. After that P4 admin needs to set P4 via `p4 triggers`. 

## Additional review information
It needs to be discussed how the trigger script should respond to errors. If there would be any error in this script it limits possibility of commit altogether. Without hard fail its difficult to see/debug that trigger is not working.
It would be possible to try to not fail in the script to allow submits all the time, but log into some file on P4 server.

## Testing notes:
1. fill AYON_SERVER_URL, AYON_API_KEY in `ayon-version-control/client/version_control/perforce_triggers/change_submit_trigger.py` before you commit it to P4 Server depot
2. use this path in `p4 triggers` command, check `ayon-version-control/client/version_control/perforce_triggers/README.md`
3. commit to monitored depot, look in AYON `Event Viewer` for `perforce.change_submit`
